### PR TITLE
Issue 32-2 표준 에러 객체 구현

### DIFF
--- a/module-api/src/main/kotlin/com/example/TestController.kt
+++ b/module-api/src/main/kotlin/com/example/TestController.kt
@@ -1,0 +1,21 @@
+package com.example
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class TestController {
+
+    @GetMapping(path = ["/test/sample"])
+    fun sample(@RequestParam message: String, @RequestParam number: Int): SampleResponse {
+        return SampleResponse("im sample: $message, $number")
+    }
+
+    @GetMapping(path = ["/test/error"])
+    fun error(@RequestParam message: String): Boolean {
+        throw RuntimeException("error!!!")
+    }
+}
+
+data class SampleResponse(val string: String)

--- a/module-api/src/main/kotlin/com/example/config/LoggerConfig.kt
+++ b/module-api/src/main/kotlin/com/example/config/LoggerConfig.kt
@@ -1,0 +1,21 @@
+package com.example.config
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.InjectionPoint
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Scope
+
+@Configuration
+class LoggerConfig {
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    fun logger(injectionPoint: InjectionPoint): Logger {
+        return LoggerFactory.getLogger(
+            injectionPoint.methodParameter?.containingClass ?: injectionPoint.field?.declaringClass
+        )
+    }
+}

--- a/module-api/src/main/kotlin/com/example/config/exception/ControllerAdvice.kt
+++ b/module-api/src/main/kotlin/com/example/config/exception/ControllerAdvice.kt
@@ -1,5 +1,6 @@
 package com.example.config.exception
 
+import org.slf4j.Logger
 import org.springframework.http.HttpStatus
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.BindException
@@ -14,7 +15,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import javax.validation.ConstraintViolationException
 
 @RestControllerAdvice
-class ControllerAdvice {
+class ControllerAdvice(private val log: Logger) {
 
     /**
      * 외부 통신 실패
@@ -112,8 +113,6 @@ class ControllerAdvice {
     }
 
     private fun preHandle(exception: Exception) {
-        // slf4j 적용 필요
-        // log.error("### message={}, cause={}", ex.message, ex.cause, ex)
-        println("### message=" + exception.message + ", cause=" + exception.cause)
+        log.error("### message={}, cause={}", exception.message, exception.cause, exception)
     }
 }

--- a/module-api/src/main/kotlin/com/example/config/exception/ControllerAdvice.kt
+++ b/module-api/src/main/kotlin/com/example/config/exception/ControllerAdvice.kt
@@ -1,0 +1,119 @@
+package com.example.config.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.BindException
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import javax.validation.ConstraintViolationException
+
+@RestControllerAdvice
+class ControllerAdvice {
+
+    /**
+     * 외부 통신 실패
+     */
+    @ExceptionHandler(HttpClientErrorException::class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    protected fun handleHttpClientErrorException(exception: HttpClientErrorException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(exception.message)
+    }
+
+    /**
+     * 지원하지 않는 HTTP method가 호출 되는 경우
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    protected fun handleHttpRequestMethodNotSupportedException(exception: HttpRequestMethodNotSupportedException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(exception.message)
+    }
+
+    /**
+     * 필수 requestParam이 누락된 경우
+     */
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleMissingServletRequestParameterException(exception: MissingServletRequestParameterException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(exception)
+    }
+
+    @ExceptionHandler(Exception::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    protected fun handleException(exception: Exception): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(exception.message)
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleHttpMessageNotReadableException(exception: HttpMessageNotReadableException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(exception.message)
+    }
+
+    /**
+     * ModelAttribute 에 binding error 발생시 BindException 발생한다.
+     */
+    @ExceptionHandler(BindException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleBindException(exception: BindException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(ErrorCode.BAD_REQUEST, exception.bindingResult)
+    }
+
+    /**
+     * type이 일치하지 않아 binding 하지 못하는 경우
+     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleMethodArgumentTypeMismatchException(exception: MethodArgumentTypeMismatchException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(exception)
+    }
+
+    /**
+     * javax.validation을 통과하지 못하면 경우
+     * ex) @NotBlank, @NotEmpty, @NotNull
+     */
+    @ExceptionHandler(ConstraintViolationException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleConstraintViolationException(exception: ConstraintViolationException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(exception)
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleIllegalArgumentException(exception: IllegalArgumentException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(ErrorCode.BAD_REQUEST)
+    }
+
+    /**
+     * Valid or Validated 으로 binding error 시 발생
+     * HttpMessageConverter 에서 등록한 HttpMessageConverter binding 이 실패하는 경우
+     * ex) @RequestBody, @RequestPart
+     */
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleMethodArgumentNotValidException(exception: MethodArgumentNotValidException): ErrorResponse {
+        preHandle(exception)
+        return ErrorResponse.of(ErrorCode.BAD_REQUEST, exception.bindingResult)
+    }
+
+    private fun preHandle(exception: Exception) {
+        // slf4j 적용 필요
+        // log.error("### message={}, cause={}", ex.message, ex.cause, ex)
+        println("### message=" + exception.message + ", cause=" + exception.cause)
+    }
+}

--- a/module-api/src/main/kotlin/com/example/config/exception/ErrorCode.kt
+++ b/module-api/src/main/kotlin/com/example/config/exception/ErrorCode.kt
@@ -1,0 +1,12 @@
+package com.example.config.exception
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(val code: String, val status: HttpStatus, val reason: String) {
+    BAD_REQUEST("0400", HttpStatus.BAD_REQUEST, "잘못된 입력 값"),
+    UNAUTHORIZED("0401", HttpStatus.UNAUTHORIZED, "인증 실패"),
+    FORBIDDEN("0403", HttpStatus.FORBIDDEN, "권한 없음"),
+    NOT_FOUND("0404", HttpStatus.NOT_FOUND, "찾을 수 없음"),
+    METHOD_NOT_ALLOWED("0405", HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메소드"),
+    UNKNOWN("0500", HttpStatus.INTERNAL_SERVER_ERROR, "알수 없는 서버 에러"),
+}

--- a/module-api/src/main/kotlin/com/example/config/exception/ErrorResponse.kt
+++ b/module-api/src/main/kotlin/com/example/config/exception/ErrorResponse.kt
@@ -1,0 +1,125 @@
+package com.example.config.exception
+
+import org.springframework.validation.BindingResult
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import java.time.LocalDateTime
+import java.util.stream.Collectors
+import javax.validation.ConstraintViolationException
+import javax.validation.Path
+
+data class ErrorResponse(
+    val code: String = "",
+    val codeName: String = "",
+    val message: String = "",
+    val time: LocalDateTime = LocalDateTime.now(),
+    val errors: List<FieldError> = ArrayList()
+) {
+    companion object {
+        private const val DEFAULT_MESSAGE = "기본 에러 메시지가 존재하지 않습니다."
+
+        fun of(errorCode: ErrorCode, bindingResult: BindingResult): ErrorResponse {
+            return ErrorResponse(
+                code = errorCode.code,
+                codeName = errorCode.name,
+                message = errorCode.reason,
+                errors = FieldError.of(bindingResult)
+            )
+        }
+
+        fun of(errorCode: ErrorCode): ErrorResponse {
+            return ErrorResponse(
+                code = errorCode.code,
+                codeName = errorCode.name,
+                message = errorCode.reason,
+            )
+        }
+
+        fun of(message: String?): ErrorResponse {
+            return ErrorResponse(message = message ?: DEFAULT_MESSAGE)
+        }
+
+        fun of(exception: MethodArgumentTypeMismatchException): ErrorResponse {
+            val fieldError = with(exception) {
+                FieldError.of(
+                    field = name,
+                    value = value?.toString() ?: "",
+                    reason = errorCode
+                )
+            }
+            return of(ErrorCode.BAD_REQUEST, listOf(fieldError))
+        }
+
+        fun of(exception: MissingServletRequestParameterException): ErrorResponse {
+            val fieldError = FieldError.of(
+                field = exception.parameterName,
+                value = "",
+                reason = "Not exist"
+            )
+            return of(ErrorCode.BAD_REQUEST, listOf(fieldError))
+        }
+
+        fun of(exception: ConstraintViolationException): ErrorResponse {
+            val fieldErrors = exception.constraintViolations.stream()
+                .map {
+                    FieldError.of(
+                        field = extractPropertyName(it.propertyPath),
+                        value = "",
+                        reason = it.message
+                    )
+                }.collect(Collectors.toList())
+            return of(ErrorCode.BAD_REQUEST, fieldErrors)
+        }
+
+        private fun of(errorCode: ErrorCode, errors: List<FieldError>): ErrorResponse {
+            return ErrorResponse(
+                code = errorCode.code,
+                codeName = errorCode.name,
+                message = errorCode.reason,
+                errors = errors
+            )
+        }
+
+        /**
+         * 속성 전체 경로에서 속성 이름만 가져옵니다.
+         */
+        private fun extractPropertyName(propertyPath: Path): String {
+            val pathString = propertyPath.toString()
+            return pathString.substring(pathString.lastIndexOf('.') + 1)
+        }
+    }
+
+    /**
+     * BAD_REQUEST를 상세히 알려주기 위한 필드 에러
+     */
+    data class FieldError(
+        val field: String,
+        val value: String,
+        val reason: String,
+    ) {
+
+        companion object {
+            fun of(field: String, value: String, reason: String): FieldError {
+                return FieldError(field, value, reason)
+            }
+
+            fun of(bindingResult: BindingResult): List<FieldError> {
+                return with(bindingResult) {
+                    fieldErrors.stream()
+                        .map { of(it) }
+                        .collect(Collectors.toList())
+                }
+            }
+
+            private fun of(fieldError: org.springframework.validation.FieldError): FieldError {
+                return with(fieldError) {
+                    FieldError(
+                        field = field,
+                        value = rejectedValue?.toString() ?: "",
+                        reason = defaultMessage ?: ""
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
> 본 작업은 ISSUE-32가 머지 되기전에 ISSUE-32 로 머지 되어야 합니다.

Java + Spring으로 사이드 프로젝트를 할 떄 사용하던 코드를 kotlin으로 개선하려고 합니다.

- 라이브러리 형태의 것으로 작업을 하려다보니 조금 복잡합니다.
- 이번 기회에 타인이 보았을 때 잘 이해되지 않는 부분에 javadoc 형태의 주석을 만들고 나아가 패키지된 라이브러리까지를 고려 중입니다.
- 어쩌면 core에 들어가야되는 것일지도..? 하지만 일단 web에 작업 하겠습니다.

---

### 목표

- 400 에러 관련을 최대한 세세하게 처리하려고 노력했습니다.
- 로컬라이제이션, 글로벌라이제이션은 배제 합니다.
    - 아마 영어나 일본어 메시지 등이 들어온다면 코드에 매칭되는 메시지를 만들고 DB로 관리해야되지 않을까 싶긴 합니다.
- 이러한 추가 작업을 하고 있다고 공유하는 차원에서 미리 공유합니다.

### 샘플

<img width="437" alt="image" src="https://user-images.githubusercontent.com/55722186/163670205-e5bcf120-d77f-43f1-b87c-feebda0cac25.png">

<img width="376" alt="image" src="https://user-images.githubusercontent.com/55722186/163670219-a7a378a2-7458-44ec-b158-1d2c19ab3143.png">
